### PR TITLE
feat: タスク管理機能（通常/Daily/曜日タスク）初期実装

### DIFF
--- a/backend/routes/tasks.js
+++ b/backend/routes/tasks.js
@@ -1,0 +1,288 @@
+const express = require('express');
+const router = express.Router();
+const pool = require('../config/database');
+const { requireAuth } = require('../middleware/auth');
+
+router.use(requireAuth);
+
+// --- ヘルパー関数 ---
+
+// 今日のタスクインスタンスを遅延生成（Daily/曜日タスク）
+async function generateTodayInstances(userId) {
+  const now = new Date();
+  const today = now.toISOString().split('T')[0];
+  const currentTime = `${String(now.getHours()).padStart(2, '0')}:${String(now.getMinutes()).padStart(2, '0')}:${String(now.getSeconds()).padStart(2, '0')}`;
+  // ISO weekday: 1=月 ... 7=日
+  const dayOfWeek = now.getDay() === 0 ? 7 : now.getDay();
+
+  const [templates] = await pool.execute(
+    `SELECT * FROM task_templates
+     WHERE user_id = ? AND is_active = TRUE
+     AND task_type IN ('daily', 'weekday')
+     AND trigger_time <= ?`,
+    [userId, currentTime]
+  );
+
+  for (const tmpl of templates) {
+    if (tmpl.task_type === 'weekday') {
+      let weekdays = [];
+      try {
+        weekdays = typeof tmpl.weekdays === 'string' ? JSON.parse(tmpl.weekdays) : (tmpl.weekdays || []);
+      } catch (e) {
+        weekdays = [];
+      }
+      if (!weekdays.includes(dayOfWeek)) continue;
+    }
+
+    // UNIQUE(template_id, scheduled_date) で重複防止
+    await pool.execute(
+      `INSERT IGNORE INTO task_instances
+       (template_id, user_id, title, description, task_type, scheduled_date)
+       VALUES (?, ?, ?, ?, ?, ?)`,
+      [tmpl.id, userId, tmpl.title, tmpl.description, tmpl.task_type, today]
+    );
+  }
+}
+
+const VALID_TASK_TYPES = ['normal', 'daily', 'weekday'];
+const VALID_WEEKDAYS = [1, 2, 3, 4, 5, 6, 7];
+
+// --- バッジ用API（ヘッダーから高頻度で呼ばれる）---
+
+// GET /api/tasks/badge - 今日の残タスク数
+router.get('/badge', async (req, res) => {
+  try {
+    await generateTodayInstances(req.session.userId);
+    const today = new Date().toISOString().split('T')[0];
+    const [rows] = await pool.execute(
+      `SELECT COUNT(*) as pending_count
+       FROM task_instances
+       WHERE user_id = ? AND scheduled_date = ? AND status = 'pending'`,
+      [req.session.userId, today]
+    );
+    res.json({ pending_count: rows[0].pending_count });
+  } catch (error) {
+    console.error('[tasks] バッジ取得エラー:', error);
+    res.status(500).json({ error: 'バッジ情報の取得に失敗しました' });
+  }
+});
+
+// --- 今日のタスク ---
+
+// GET /api/tasks/today - 今日のタスクインスタンス一覧
+router.get('/today', async (req, res) => {
+  try {
+    await generateTodayInstances(req.session.userId);
+    const today = new Date().toISOString().split('T')[0];
+    const [instances] = await pool.execute(
+      `SELECT ti.*, tt.trigger_time
+       FROM task_instances ti
+       LEFT JOIN task_templates tt ON ti.template_id = tt.id
+       WHERE ti.user_id = ? AND ti.scheduled_date = ?
+       ORDER BY ti.status ASC, tt.trigger_time ASC, ti.created_at ASC`,
+      [req.session.userId, today]
+    );
+    res.json(instances);
+  } catch (error) {
+    console.error('[tasks] 今日のタスク取得エラー:', error);
+    res.status(500).json({ error: '今日のタスクの取得に失敗しました' });
+  }
+});
+
+// --- インスタンス操作 ---
+
+// PUT /api/tasks/instances/:id/complete - タスク完了
+router.put('/instances/:id/complete', async (req, res) => {
+  try {
+    const [result] = await pool.execute(
+      `UPDATE task_instances SET status = 'completed', completed_at = NOW()
+       WHERE id = ? AND user_id = ?`,
+      [req.params.id, req.session.userId]
+    );
+    if (result.affectedRows === 0) {
+      return res.status(404).json({ error: 'タスクが見つかりません' });
+    }
+    res.json({ message: 'タスクを完了しました' });
+  } catch (error) {
+    console.error('[tasks] タスク完了エラー:', error);
+    res.status(500).json({ error: 'タスクの完了に失敗しました' });
+  }
+});
+
+// PUT /api/tasks/instances/:id/skip - タスクスキップ
+router.put('/instances/:id/skip', async (req, res) => {
+  try {
+    const [result] = await pool.execute(
+      `UPDATE task_instances SET status = 'skipped'
+       WHERE id = ? AND user_id = ?`,
+      [req.params.id, req.session.userId]
+    );
+    if (result.affectedRows === 0) {
+      return res.status(404).json({ error: 'タスクが見つかりません' });
+    }
+    res.json({ message: 'タスクをスキップしました' });
+  } catch (error) {
+    console.error('[tasks] タスクスキップエラー:', error);
+    res.status(500).json({ error: 'タスクのスキップに失敗しました' });
+  }
+});
+
+// PUT /api/tasks/instances/:id/revert - タスクを未完了に戻す
+router.put('/instances/:id/revert', async (req, res) => {
+  try {
+    const [result] = await pool.execute(
+      `UPDATE task_instances SET status = 'pending', completed_at = NULL
+       WHERE id = ? AND user_id = ?`,
+      [req.params.id, req.session.userId]
+    );
+    if (result.affectedRows === 0) {
+      return res.status(404).json({ error: 'タスクが見つかりません' });
+    }
+    res.json({ message: 'タスクを未完了に戻しました' });
+  } catch (error) {
+    console.error('[tasks] タスク戻しエラー:', error);
+    res.status(500).json({ error: 'タスクの状態変更に失敗しました' });
+  }
+});
+
+// --- テンプレート管理 ---
+
+// GET /api/tasks/templates - テンプレート一覧
+router.get('/templates', async (req, res) => {
+  try {
+    const [templates] = await pool.execute(
+      `SELECT * FROM task_templates
+       WHERE user_id = ?
+       ORDER BY task_type ASC, trigger_time ASC, created_at DESC`,
+      [req.session.userId]
+    );
+    res.json(templates);
+  } catch (error) {
+    console.error('[tasks] テンプレート一覧取得エラー:', error);
+    res.status(500).json({ error: 'テンプレートの取得に失敗しました' });
+  }
+});
+
+// POST /api/tasks/templates - テンプレート作成
+router.post('/templates', async (req, res) => {
+  try {
+    const { title, description, task_type, trigger_time, weekdays } = req.body;
+
+    // バリデーション
+    if (!title || !title.trim()) {
+      return res.status(400).json({ error: 'タイトルは必須です' });
+    }
+    if (!VALID_TASK_TYPES.includes(task_type)) {
+      return res.status(400).json({ error: '無効なタスクタイプです' });
+    }
+    if (task_type === 'weekday') {
+      if (!Array.isArray(weekdays) || weekdays.length === 0) {
+        return res.status(400).json({ error: '曜日タスクには曜日の指定が必要です' });
+      }
+      if (!weekdays.every(d => VALID_WEEKDAYS.includes(d))) {
+        return res.status(400).json({ error: '無効な曜日が含まれています' });
+      }
+    }
+
+    const [result] = await pool.execute(
+      `INSERT INTO task_templates (user_id, title, description, task_type, trigger_time, weekdays)
+       VALUES (?, ?, ?, ?, ?, ?)`,
+      [
+        req.session.userId,
+        title.trim(),
+        description ? description.trim() : null,
+        task_type,
+        (task_type === 'daily' || task_type === 'weekday') && trigger_time ? trigger_time : '09:00:00',
+        task_type === 'weekday' ? JSON.stringify(weekdays) : null
+      ]
+    );
+
+    const templateId = result.insertId;
+
+    // 通常タスクの場合、即座にインスタンスを生成
+    if (task_type === 'normal') {
+      const today = new Date().toISOString().split('T')[0];
+      await pool.execute(
+        `INSERT INTO task_instances (template_id, user_id, title, description, task_type, scheduled_date)
+         VALUES (?, ?, ?, ?, 'normal', ?)`,
+        [templateId, req.session.userId, title.trim(), description ? description.trim() : null, today]
+      );
+    }
+
+    const [created] = await pool.execute(
+      'SELECT * FROM task_templates WHERE id = ?',
+      [templateId]
+    );
+
+    res.status(201).json(created[0]);
+  } catch (error) {
+    console.error('[tasks] テンプレート作成エラー:', error);
+    res.status(500).json({ error: 'テンプレートの作成に失敗しました' });
+  }
+});
+
+// PUT /api/tasks/templates/:id - テンプレート更新
+router.put('/templates/:id', async (req, res) => {
+  try {
+    const { title, description, task_type, trigger_time, weekdays, is_active } = req.body;
+
+    if (title !== undefined && (!title || !title.trim())) {
+      return res.status(400).json({ error: 'タイトルは必須です' });
+    }
+    if (task_type !== undefined && !VALID_TASK_TYPES.includes(task_type)) {
+      return res.status(400).json({ error: '無効なタスクタイプです' });
+    }
+
+    const updates = [];
+    const params = [];
+
+    if (title !== undefined) { updates.push('title = ?'); params.push(title.trim()); }
+    if (description !== undefined) { updates.push('description = ?'); params.push(description ? description.trim() : null); }
+    if (task_type !== undefined) { updates.push('task_type = ?'); params.push(task_type); }
+    if (trigger_time !== undefined) { updates.push('trigger_time = ?'); params.push(trigger_time); }
+    if (weekdays !== undefined) { updates.push('weekdays = ?'); params.push(JSON.stringify(weekdays)); }
+    if (is_active !== undefined) { updates.push('is_active = ?'); params.push(is_active ? 1 : 0); }
+
+    if (updates.length === 0) {
+      return res.status(400).json({ error: '更新する項目がありません' });
+    }
+
+    params.push(req.params.id, req.session.userId);
+    const [result] = await pool.execute(
+      `UPDATE task_templates SET ${updates.join(', ')} WHERE id = ? AND user_id = ?`,
+      params
+    );
+
+    if (result.affectedRows === 0) {
+      return res.status(404).json({ error: 'テンプレートが見つかりません' });
+    }
+
+    const [updated] = await pool.execute(
+      'SELECT * FROM task_templates WHERE id = ?',
+      [req.params.id]
+    );
+    res.json(updated[0]);
+  } catch (error) {
+    console.error('[tasks] テンプレート更新エラー:', error);
+    res.status(500).json({ error: 'テンプレートの更新に失敗しました' });
+  }
+});
+
+// DELETE /api/tasks/templates/:id - テンプレート削除
+router.delete('/templates/:id', async (req, res) => {
+  try {
+    const [result] = await pool.execute(
+      'DELETE FROM task_templates WHERE id = ? AND user_id = ?',
+      [req.params.id, req.session.userId]
+    );
+    if (result.affectedRows === 0) {
+      return res.status(404).json({ error: 'テンプレートが見つかりません' });
+    }
+    res.json({ message: 'テンプレートを削除しました' });
+  } catch (error) {
+    console.error('[tasks] テンプレート削除エラー:', error);
+    res.status(500).json({ error: 'テンプレートの削除に失敗しました' });
+  }
+});
+
+module.exports = router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -15,6 +15,7 @@ const recordingsRoutes = require('./routes/recordings');
 const transcribeRoutes = require('./routes/transcribe');
 const knowledgeRoutes = require('./routes/knowledge');
 const quizzesRoutes = require('./routes/quizzes');
+const tasksRoutes = require('./routes/tasks');
 const pool = require('./config/database');
 
 const app = express();
@@ -69,6 +70,7 @@ app.use('/api/recordings', recordingsRoutes);
 app.use('/api', transcribeRoutes);
 app.use('/api/knowledge', knowledgeRoutes);
 app.use('/api', quizzesRoutes);
+app.use('/api/tasks', tasksRoutes);
 
 app.listen(PORT, '0.0.0.0', () => {
   console.log(`Server is running on port ${PORT}`);

--- a/docker/mysql/init/013_create_task_tables.sql
+++ b/docker/mysql/init/013_create_task_tables.sql
@@ -1,0 +1,36 @@
+-- タスク管理機能テーブル
+-- task_templates: タスク定義（通常/Daily/曜日）
+-- task_instances: タスクインスタンス（実行単位）
+
+CREATE TABLE IF NOT EXISTS task_templates (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    user_id INT NOT NULL,
+    title VARCHAR(255) NOT NULL,
+    description TEXT DEFAULT NULL,
+    task_type ENUM('normal', 'daily', 'weekday') NOT NULL DEFAULT 'normal',
+    trigger_time TIME DEFAULT '09:00:00',
+    weekdays JSON DEFAULT NULL,
+    is_active BOOLEAN NOT NULL DEFAULT TRUE,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+    INDEX idx_user_active (user_id, is_active),
+    INDEX idx_user_type (user_id, task_type)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS task_instances (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    template_id INT DEFAULT NULL,
+    user_id INT NOT NULL,
+    title VARCHAR(255) NOT NULL,
+    description TEXT DEFAULT NULL,
+    task_type ENUM('normal', 'daily', 'weekday') NOT NULL DEFAULT 'normal',
+    scheduled_date DATE NOT NULL,
+    status ENUM('pending', 'completed', 'skipped') NOT NULL DEFAULT 'pending',
+    completed_at TIMESTAMP NULL DEFAULT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (template_id) REFERENCES task_templates(id) ON DELETE SET NULL,
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+    INDEX idx_user_date_status (user_id, scheduled_date, status),
+    UNIQUE KEY uk_template_date (template_id, scheduled_date)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -12,6 +12,7 @@ import VoiceTest from './components/VoiceTest';
 import KnowledgeList from './components/KnowledgeList';
 import KnowledgeForm from './components/KnowledgeForm';
 import KnowledgeDetail from './components/KnowledgeDetail';
+import TaskList from './components/TaskList';
 import { ToastProvider } from './components/Toast';
 import './App.css';
 
@@ -83,6 +84,7 @@ function App() {
                   <Route path="/knowledge/new" element={<KnowledgeForm />} />
                   <Route path="/knowledge/:id" element={<KnowledgeDetail />} />
                   <Route path="/knowledge/:id/edit" element={<KnowledgeForm />} />
+                  <Route path="/tasks" element={<TaskList />} />
                   <Route path="/voice-test" element={<VoiceTest />} />
                   <Route path="/auth/google/callback" element={<GoogleCallback />} />
                   <Route path="*" element={<Navigate to="/" replace />} />

--- a/frontend/src/components/Header.js
+++ b/frontend/src/components/Header.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import TaskBadge from './TaskBadge';
 import './Header.css';
 
 function Header({ user, onLogout, theme, onThemeToggle }) {
@@ -8,6 +9,7 @@ function Header({ user, onLogout, theme, onThemeToggle }) {
         <span className="header-title">Reflexio</span>
       </div>
       <div className="header-right">
+        <TaskBadge />
         <button className="theme-toggle" onClick={onThemeToggle} title={theme === 'dark' ? 'ライトモードに切替' : 'ダークモードに切替'}>
           {theme === 'dark' ? '☀️' : '🌙'}
         </button>

--- a/frontend/src/components/Sidebar.js
+++ b/frontend/src/components/Sidebar.js
@@ -8,7 +8,7 @@ const menuItems = [
   { path: '/accounting', label: 'Accounting', short: 'A' },
   { path: '/notes', label: 'Notes', short: 'N' },
   { path: '/knowledge', label: '📚 学習', short: '📚' },
-  { path: '/tasks', label: 'Task Management', short: 'T' },
+  { path: '/tasks', label: '✅ タスク管理', short: '✅' },
   { path: '/settings', label: '⚙️ 設定', short: '⚙️' },
   { path: '/clawdbot', label: '🤖 Clawdbot Badge', short: '🤖' },
   { path: '/voice-test', label: '🎤 Voice Test', short: 'Mic' },

--- a/frontend/src/components/TaskBadge.css
+++ b/frontend/src/components/TaskBadge.css
@@ -1,0 +1,48 @@
+.task-badge-button {
+  position: relative;
+  display: flex;
+  align-items: center;
+  background: transparent;
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  border-radius: 12px;
+  padding: 3px 10px;
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+.task-badge-button:hover {
+  background-color: rgba(255, 255, 255, 0.1);
+}
+
+.task-badge-label {
+  color: var(--header-text);
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.3px;
+}
+
+.task-badge-count {
+  position: absolute;
+  top: -6px;
+  right: -6px;
+  min-width: 18px;
+  height: 18px;
+  background-color: #e74c3c;
+  color: #fff;
+  font-size: 11px;
+  font-weight: 700;
+  border-radius: 9px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 4px;
+  line-height: 1;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
+  animation: task-badge-pop 0.3s ease-out;
+}
+
+@keyframes task-badge-pop {
+  0% { transform: scale(0); }
+  60% { transform: scale(1.2); }
+  100% { transform: scale(1); }
+}

--- a/frontend/src/components/TaskBadge.js
+++ b/frontend/src/components/TaskBadge.js
@@ -1,0 +1,64 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import { useNavigate } from 'react-router-dom';
+import './TaskBadge.css';
+
+const API_URL = process.env.REACT_APP_API_URL || `http://${window.location.hostname}:3002`;
+
+function TaskBadge() {
+  const [pendingCount, setPendingCount] = useState(0);
+  const navigate = useNavigate();
+
+  const fetchBadgeCount = useCallback(async () => {
+    try {
+      const response = await fetch(`${API_URL}/api/tasks/badge`, {
+        credentials: 'include'
+      });
+      if (response.ok) {
+        const data = await response.json();
+        setPendingCount(data.pending_count);
+      }
+    } catch (error) {
+      // バッジ取得失敗は静かに無視（ヘッダーの動作を妨げない）
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchBadgeCount();
+
+    // 60秒ごとにポーリング
+    const interval = setInterval(fetchBadgeCount, 60000);
+
+    // タブがアクティブになったら即リフレッシュ
+    const handleVisibility = () => {
+      if (document.visibilityState === 'visible') {
+        fetchBadgeCount();
+      }
+    };
+    document.addEventListener('visibilitychange', handleVisibility);
+
+    // カスタムイベントでリフレッシュ（タスク完了時などに発火）
+    const handleRefresh = () => fetchBadgeCount();
+    window.addEventListener('task-badge-refresh', handleRefresh);
+
+    return () => {
+      clearInterval(interval);
+      document.removeEventListener('visibilitychange', handleVisibility);
+      window.removeEventListener('task-badge-refresh', handleRefresh);
+    };
+  }, [fetchBadgeCount]);
+
+  const handleClick = () => {
+    navigate('/tasks');
+  };
+
+  return (
+    <button className="task-badge-button" onClick={handleClick} title="今日のタスク">
+      <span className="task-badge-label">DailyTask</span>
+      {pendingCount > 0 && (
+        <span className="task-badge-count">{pendingCount > 99 ? '99+' : pendingCount}</span>
+      )}
+    </button>
+  );
+}
+
+export default TaskBadge;

--- a/frontend/src/components/TaskList.css
+++ b/frontend/src/components/TaskList.css
@@ -1,0 +1,377 @@
+.task-list-container {
+  padding: 20px;
+  max-width: 900px;
+}
+
+.task-loading {
+  padding: 40px;
+  text-align: center;
+  color: var(--text-secondary);
+}
+
+/* ヘッダー */
+.task-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 16px;
+}
+
+.task-header h2 {
+  margin: 0;
+  color: var(--text-primary);
+  font-size: 20px;
+}
+
+.task-add-button {
+  background-color: var(--btn-primary-bg, #3498db);
+  color: #fff;
+  border: none;
+  padding: 8px 16px;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 14px;
+  font-weight: 600;
+  transition: background-color 0.2s;
+}
+
+.task-add-button:hover {
+  background-color: var(--btn-primary-hover-bg, #2980b9);
+}
+
+/* タブ */
+.task-tabs {
+  display: flex;
+  gap: 0;
+  border-bottom: 2px solid var(--border-color, #ddd);
+  margin-bottom: 20px;
+}
+
+.task-tab {
+  background: transparent;
+  border: none;
+  padding: 10px 20px;
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--text-secondary);
+  cursor: pointer;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -2px;
+  transition: color 0.2s, border-color 0.2s;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.task-tab:hover {
+  color: var(--text-primary);
+}
+
+.task-tab.active {
+  color: var(--btn-primary-bg, #3498db);
+  border-bottom-color: var(--btn-primary-bg, #3498db);
+  font-weight: 600;
+}
+
+.task-tab-badge {
+  background-color: #e74c3c;
+  color: #fff;
+  font-size: 11px;
+  font-weight: 700;
+  min-width: 18px;
+  height: 18px;
+  border-radius: 9px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 4px;
+}
+
+.task-tab-count {
+  color: var(--text-secondary);
+  font-size: 12px;
+}
+
+/* 空状態 */
+.task-empty {
+  text-align: center;
+  padding: 40px 20px;
+  color: var(--text-secondary);
+}
+
+.task-empty p {
+  margin: 4px 0;
+}
+
+.task-empty-hint {
+  font-size: 13px;
+  opacity: 0.7;
+}
+
+/* タスクグループ */
+.task-group {
+  margin-bottom: 24px;
+}
+
+.task-group-title {
+  font-size: 14px;
+  color: var(--text-secondary);
+  margin: 0 0 8px 0;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.task-group-title.completed-title {
+  color: #27ae60;
+}
+
+.task-group-title.skipped-title {
+  color: #95a5a6;
+}
+
+.task-group-count {
+  font-size: 12px;
+  opacity: 0.8;
+}
+
+/* チェックリスト */
+.task-checklist {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.task-item {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 12px;
+  border-radius: 8px;
+  margin-bottom: 4px;
+  background-color: var(--card-bg, #fff);
+  border: 1px solid var(--border-color, #e0e0e0);
+  transition: background-color 0.15s, transform 0.15s;
+}
+
+.task-item:hover {
+  background-color: var(--hover-bg, #f5f5f5);
+}
+
+.task-item.completed {
+  opacity: 0.65;
+}
+
+.task-item.completed .task-item-title {
+  text-decoration: line-through;
+  color: var(--text-secondary);
+}
+
+.task-item.skipped {
+  opacity: 0.5;
+}
+
+.task-item.skipped .task-item-title {
+  text-decoration: line-through;
+  color: var(--text-secondary);
+}
+
+/* チェックボックス */
+.task-checkbox {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  border: 2px solid var(--border-color, #ccc);
+  background: transparent;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  transition: border-color 0.2s, background-color 0.2s;
+}
+
+.task-checkbox:hover {
+  border-color: #27ae60;
+  background-color: rgba(39, 174, 96, 0.1);
+}
+
+.task-checkbox.checked {
+  border-color: #27ae60;
+  background-color: #27ae60;
+}
+
+.task-checkbox.checked .checkbox-icon {
+  color: #fff;
+}
+
+.checkbox-icon {
+  font-size: 14px;
+  color: var(--text-secondary);
+}
+
+/* タスク内容 */
+.task-item-content {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.task-item-title {
+  font-size: 14px;
+  color: var(--text-primary);
+  font-weight: 500;
+}
+
+.task-item-desc {
+  font-size: 12px;
+  color: var(--text-secondary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* タイプバッジ */
+.task-type-badge {
+  color: #fff;
+  font-size: 10px;
+  font-weight: 700;
+  padding: 2px 8px;
+  border-radius: 10px;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+/* スキップボタン */
+.task-skip-button {
+  background: transparent;
+  border: 1px solid var(--border-color, #ccc);
+  color: var(--text-secondary);
+  padding: 3px 8px;
+  border-radius: 4px;
+  font-size: 11px;
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: background-color 0.2s;
+}
+
+.task-skip-button:hover {
+  background-color: var(--hover-bg, #f0f0f0);
+}
+
+/* テンプレートテーブル */
+.task-template-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+}
+
+.task-template-table th {
+  text-align: left;
+  padding: 8px 10px;
+  border-bottom: 2px solid var(--border-color, #ddd);
+  color: var(--text-secondary);
+  font-weight: 600;
+  font-size: 12px;
+  white-space: nowrap;
+}
+
+.task-template-table td {
+  padding: 10px;
+  border-bottom: 1px solid var(--border-color, #eee);
+  color: var(--text-primary);
+  vertical-align: middle;
+}
+
+.task-template-table tbody tr:hover {
+  background-color: var(--hover-bg, #f9f9f9);
+}
+
+.inactive-row {
+  opacity: 0.5;
+}
+
+.template-title {
+  font-weight: 500;
+}
+
+.template-desc {
+  font-size: 11px;
+  color: var(--text-secondary);
+  margin-top: 2px;
+}
+
+/* 曜日チップ */
+.weekday-chips {
+  display: flex;
+  gap: 3px;
+}
+
+.weekday-chip {
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 10px;
+  font-weight: 600;
+  background-color: var(--border-color, #e0e0e0);
+  color: var(--text-secondary);
+}
+
+.weekday-chip.active {
+  background-color: #3498db;
+  color: #fff;
+}
+
+/* ON/OFFトグル */
+.toggle-active-btn {
+  border: none;
+  padding: 3px 10px;
+  border-radius: 10px;
+  font-size: 11px;
+  font-weight: 700;
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+.toggle-active-btn.on {
+  background-color: #27ae60;
+  color: #fff;
+}
+
+.toggle-active-btn.off {
+  background-color: var(--border-color, #ccc);
+  color: var(--text-secondary);
+}
+
+/* テンプレート操作ボタン */
+.template-actions {
+  display: flex;
+  gap: 6px;
+}
+
+.template-edit-btn,
+.template-delete-btn {
+  border: 1px solid var(--border-color, #ccc);
+  background: transparent;
+  color: var(--text-primary);
+  padding: 4px 10px;
+  border-radius: 4px;
+  font-size: 12px;
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+.template-edit-btn:hover {
+  background-color: var(--hover-bg, #f0f0f0);
+}
+
+.template-delete-btn:hover {
+  background-color: #e74c3c;
+  color: #fff;
+  border-color: #e74c3c;
+}

--- a/frontend/src/components/TaskList.js
+++ b/frontend/src/components/TaskList.js
@@ -1,0 +1,391 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import { useToast } from './Toast';
+import TaskTemplateForm from './TaskTemplateForm';
+import './TaskList.css';
+
+const API_URL = process.env.REACT_APP_API_URL || `http://${window.location.hostname}:3002`;
+
+const WEEKDAY_LABELS = ['', '月', '火', '水', '木', '金', '土', '日'];
+const TYPE_LABELS = { normal: '通常', daily: 'Daily', weekday: '曜日' };
+const TYPE_COLORS = { normal: '#7f8c8d', daily: '#e74c3c', weekday: '#3498db' };
+
+function TaskList() {
+  const [todayTasks, setTodayTasks] = useState([]);
+  const [templates, setTemplates] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [showForm, setShowForm] = useState(false);
+  const [editingTemplate, setEditingTemplate] = useState(null);
+  const [activeTab, setActiveTab] = useState('today'); // 'today' | 'templates'
+  const showToast = useToast();
+
+  const fetchTodayTasks = useCallback(async () => {
+    try {
+      const response = await fetch(`${API_URL}/api/tasks/today`, {
+        credentials: 'include'
+      });
+      if (response.ok) {
+        const data = await response.json();
+        setTodayTasks(data);
+      } else {
+        showToast('タスクの取得に失敗しました', 'error');
+      }
+    } catch (error) {
+      console.error('[tasks] 取得エラー:', error);
+      showToast('タスクの取得に失敗しました', 'error');
+    }
+  }, [showToast]);
+
+  const fetchTemplates = useCallback(async () => {
+    try {
+      const response = await fetch(`${API_URL}/api/tasks/templates`, {
+        credentials: 'include'
+      });
+      if (response.ok) {
+        const data = await response.json();
+        setTemplates(data);
+      }
+    } catch (error) {
+      console.error('[tasks] テンプレート取得エラー:', error);
+    }
+  }, []);
+
+  useEffect(() => {
+    const loadAll = async () => {
+      setLoading(true);
+      await Promise.all([fetchTodayTasks(), fetchTemplates()]);
+      setLoading(false);
+    };
+    loadAll();
+  }, [fetchTodayTasks, fetchTemplates]);
+
+  const refreshBadge = () => {
+    window.dispatchEvent(new Event('task-badge-refresh'));
+  };
+
+  const handleComplete = async (instanceId) => {
+    try {
+      const response = await fetch(`${API_URL}/api/tasks/instances/${instanceId}/complete`, {
+        method: 'PUT',
+        credentials: 'include'
+      });
+      if (response.ok) {
+        showToast('タスクを完了しました！', 'success');
+        fetchTodayTasks();
+        refreshBadge();
+      } else {
+        showToast('タスクの完了に失敗しました', 'error');
+      }
+    } catch (error) {
+      showToast('タスクの完了に失敗しました', 'error');
+    }
+  };
+
+  const handleSkip = async (instanceId) => {
+    try {
+      const response = await fetch(`${API_URL}/api/tasks/instances/${instanceId}/skip`, {
+        method: 'PUT',
+        credentials: 'include'
+      });
+      if (response.ok) {
+        showToast('タスクをスキップしました', 'success');
+        fetchTodayTasks();
+        refreshBadge();
+      }
+    } catch (error) {
+      showToast('スキップに失敗しました', 'error');
+    }
+  };
+
+  const handleRevert = async (instanceId) => {
+    try {
+      const response = await fetch(`${API_URL}/api/tasks/instances/${instanceId}/revert`, {
+        method: 'PUT',
+        credentials: 'include'
+      });
+      if (response.ok) {
+        showToast('タスクを未完了に戻しました', 'success');
+        fetchTodayTasks();
+        refreshBadge();
+      }
+    } catch (error) {
+      showToast('状態変更に失敗しました', 'error');
+    }
+  };
+
+  const handleDeleteTemplate = async (templateId) => {
+    if (!window.confirm('このテンプレートを削除しますか？')) return;
+    try {
+      const response = await fetch(`${API_URL}/api/tasks/templates/${templateId}`, {
+        method: 'DELETE',
+        credentials: 'include'
+      });
+      if (response.ok) {
+        showToast('テンプレートを削除しました', 'success');
+        fetchTemplates();
+        fetchTodayTasks();
+        refreshBadge();
+      } else {
+        showToast('削除に失敗しました', 'error');
+      }
+    } catch (error) {
+      showToast('削除に失敗しました', 'error');
+    }
+  };
+
+  const handleToggleActive = async (template) => {
+    try {
+      const response = await fetch(`${API_URL}/api/tasks/templates/${template.id}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ is_active: !template.is_active })
+      });
+      if (response.ok) {
+        showToast(template.is_active ? 'テンプレートを無効にしました' : 'テンプレートを有効にしました', 'success');
+        fetchTemplates();
+      }
+    } catch (error) {
+      showToast('変更に失敗しました', 'error');
+    }
+  };
+
+  const handleFormSave = () => {
+    setShowForm(false);
+    setEditingTemplate(null);
+    fetchTemplates();
+    fetchTodayTasks();
+    refreshBadge();
+  };
+
+  const handleFormCancel = () => {
+    setShowForm(false);
+    setEditingTemplate(null);
+  };
+
+  const pendingTasks = todayTasks.filter(t => t.status === 'pending');
+  const completedTasks = todayTasks.filter(t => t.status === 'completed');
+  const skippedTasks = todayTasks.filter(t => t.status === 'skipped');
+
+  if (loading) {
+    return <div className="task-loading">読み込み中...</div>;
+  }
+
+  return (
+    <div className="task-list-container">
+      <div className="task-header">
+        <h2>タスク管理</h2>
+        <button className="task-add-button" onClick={() => { setEditingTemplate(null); setShowForm(true); }}>
+          + 新しいタスク
+        </button>
+      </div>
+
+      {/* タブ切替 */}
+      <div className="task-tabs">
+        <button
+          className={`task-tab ${activeTab === 'today' ? 'active' : ''}`}
+          onClick={() => setActiveTab('today')}
+        >
+          今日のタスク
+          {pendingTasks.length > 0 && <span className="task-tab-badge">{pendingTasks.length}</span>}
+        </button>
+        <button
+          className={`task-tab ${activeTab === 'templates' ? 'active' : ''}`}
+          onClick={() => setActiveTab('templates')}
+        >
+          テンプレート管理
+          <span className="task-tab-count">({templates.length})</span>
+        </button>
+      </div>
+
+      {/* 今日のタスク */}
+      {activeTab === 'today' && (
+        <div className="task-today-section">
+          {todayTasks.length === 0 ? (
+            <div className="task-empty">
+              <p>今日のタスクはありません</p>
+              <p className="task-empty-hint">「+ 新しいタスク」からDailyタスクを登録しましょう</p>
+            </div>
+          ) : (
+            <>
+              {/* 未完了 */}
+              {pendingTasks.length > 0 && (
+                <div className="task-group">
+                  <h3 className="task-group-title">
+                    未完了 <span className="task-group-count">{pendingTasks.length}件</span>
+                  </h3>
+                  <ul className="task-checklist">
+                    {pendingTasks.map(task => (
+                      <li key={task.id} className="task-item pending">
+                        <button
+                          className="task-checkbox"
+                          onClick={() => handleComplete(task.id)}
+                          title="完了にする"
+                        >
+                          <span className="checkbox-icon">○</span>
+                        </button>
+                        <div className="task-item-content">
+                          <span className="task-item-title">{task.title}</span>
+                          {task.description && <span className="task-item-desc">{task.description}</span>}
+                        </div>
+                        <span className="task-type-badge" style={{ backgroundColor: TYPE_COLORS[task.task_type] }}>
+                          {TYPE_LABELS[task.task_type]}
+                        </span>
+                        <button className="task-skip-button" onClick={() => handleSkip(task.id)} title="スキップ">
+                          Skip
+                        </button>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+
+              {/* 完了済み */}
+              {completedTasks.length > 0 && (
+                <div className="task-group">
+                  <h3 className="task-group-title completed-title">
+                    完了 <span className="task-group-count">{completedTasks.length}件</span>
+                  </h3>
+                  <ul className="task-checklist">
+                    {completedTasks.map(task => (
+                      <li key={task.id} className="task-item completed">
+                        <button
+                          className="task-checkbox checked"
+                          onClick={() => handleRevert(task.id)}
+                          title="未完了に戻す"
+                        >
+                          <span className="checkbox-icon">✓</span>
+                        </button>
+                        <div className="task-item-content">
+                          <span className="task-item-title">{task.title}</span>
+                        </div>
+                        <span className="task-type-badge" style={{ backgroundColor: TYPE_COLORS[task.task_type], opacity: 0.6 }}>
+                          {TYPE_LABELS[task.task_type]}
+                        </span>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+
+              {/* スキップ済み */}
+              {skippedTasks.length > 0 && (
+                <div className="task-group">
+                  <h3 className="task-group-title skipped-title">
+                    スキップ <span className="task-group-count">{skippedTasks.length}件</span>
+                  </h3>
+                  <ul className="task-checklist">
+                    {skippedTasks.map(task => (
+                      <li key={task.id} className="task-item skipped">
+                        <button
+                          className="task-checkbox"
+                          onClick={() => handleRevert(task.id)}
+                          title="未完了に戻す"
+                        >
+                          <span className="checkbox-icon">–</span>
+                        </button>
+                        <div className="task-item-content">
+                          <span className="task-item-title">{task.title}</span>
+                        </div>
+                        <span className="task-type-badge" style={{ backgroundColor: TYPE_COLORS[task.task_type], opacity: 0.5 }}>
+                          {TYPE_LABELS[task.task_type]}
+                        </span>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+            </>
+          )}
+        </div>
+      )}
+
+      {/* テンプレート管理 */}
+      {activeTab === 'templates' && (
+        <div className="task-templates-section">
+          {templates.length === 0 ? (
+            <div className="task-empty">
+              <p>テンプレートが登録されていません</p>
+            </div>
+          ) : (
+            <table className="task-template-table">
+              <thead>
+                <tr>
+                  <th>タイトル</th>
+                  <th>タイプ</th>
+                  <th>トリガー時刻</th>
+                  <th>曜日</th>
+                  <th>有効</th>
+                  <th>操作</th>
+                </tr>
+              </thead>
+              <tbody>
+                {templates.map(tmpl => (
+                  <tr key={tmpl.id} className={!tmpl.is_active ? 'inactive-row' : ''}>
+                    <td>
+                      <div className="template-title">{tmpl.title}</div>
+                      {tmpl.description && <div className="template-desc">{tmpl.description}</div>}
+                    </td>
+                    <td>
+                      <span className="task-type-badge" style={{ backgroundColor: TYPE_COLORS[tmpl.task_type] }}>
+                        {TYPE_LABELS[tmpl.task_type]}
+                      </span>
+                    </td>
+                    <td>
+                      {(tmpl.task_type === 'daily' || tmpl.task_type === 'weekday')
+                        ? (tmpl.trigger_time || '09:00').substring(0, 5)
+                        : '-'}
+                    </td>
+                    <td>
+                      {tmpl.task_type === 'weekday' ? (
+                        <div className="weekday-chips">
+                          {(() => {
+                            let wd = [];
+                            try { wd = typeof tmpl.weekdays === 'string' ? JSON.parse(tmpl.weekdays) : (tmpl.weekdays || []); } catch(e) { wd = []; }
+                            return [1,2,3,4,5,6,7].map(d => (
+                              <span key={d} className={`weekday-chip ${wd.includes(d) ? 'active' : ''}`}>
+                                {WEEKDAY_LABELS[d]}
+                              </span>
+                            ));
+                          })()}
+                        </div>
+                      ) : '-'}
+                    </td>
+                    <td>
+                      <button
+                        className={`toggle-active-btn ${tmpl.is_active ? 'on' : 'off'}`}
+                        onClick={() => handleToggleActive(tmpl)}
+                      >
+                        {tmpl.is_active ? 'ON' : 'OFF'}
+                      </button>
+                    </td>
+                    <td>
+                      <div className="template-actions">
+                        <button className="template-edit-btn" onClick={() => { setEditingTemplate(tmpl); setShowForm(true); }}>
+                          編集
+                        </button>
+                        <button className="template-delete-btn" onClick={() => handleDeleteTemplate(tmpl.id)}>
+                          削除
+                        </button>
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </div>
+      )}
+
+      {/* テンプレート作成/編集フォーム */}
+      {showForm && (
+        <TaskTemplateForm
+          template={editingTemplate}
+          onSave={handleFormSave}
+          onCancel={handleFormCancel}
+        />
+      )}
+    </div>
+  );
+}
+
+export default TaskList;

--- a/frontend/src/components/TaskTemplateForm.css
+++ b/frontend/src/components/TaskTemplateForm.css
@@ -1,0 +1,193 @@
+.task-form-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.task-form-modal {
+  background-color: var(--card-bg, #fff);
+  border-radius: 12px;
+  padding: 24px;
+  width: 90%;
+  max-width: 480px;
+  max-height: 90vh;
+  overflow-y: auto;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);
+}
+
+.task-form-modal h3 {
+  margin: 0 0 20px 0;
+  color: var(--text-primary);
+  font-size: 18px;
+}
+
+.task-form-field {
+  margin-bottom: 16px;
+}
+
+.task-form-field label {
+  display: block;
+  margin-bottom: 4px;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+
+.required {
+  color: #e74c3c;
+}
+
+.task-form-field input[type="text"],
+.task-form-field input[type="time"],
+.task-form-field textarea {
+  width: 100%;
+  padding: 8px 10px;
+  border: 1px solid var(--border-color, #ccc);
+  border-radius: 6px;
+  font-size: 14px;
+  background-color: var(--input-bg, #fff);
+  color: var(--text-primary);
+  box-sizing: border-box;
+}
+
+.task-form-field textarea {
+  resize: vertical;
+}
+
+.task-form-field input:focus,
+.task-form-field textarea:focus {
+  outline: none;
+  border-color: var(--btn-primary-bg, #3498db);
+  box-shadow: 0 0 0 2px rgba(52, 152, 219, 0.2);
+}
+
+.field-hint {
+  display: block;
+  margin-top: 4px;
+  font-size: 11px;
+  color: var(--text-secondary);
+  opacity: 0.7;
+}
+
+/* タスクタイプセレクター */
+.task-type-selector {
+  display: flex;
+  gap: 8px;
+}
+
+.type-option {
+  flex: 1;
+  padding: 10px 8px;
+  border: 2px solid var(--border-color, #ddd);
+  border-radius: 8px;
+  background: transparent;
+  cursor: pointer;
+  text-align: center;
+  transition: border-color 0.2s, background-color 0.2s;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.type-option:hover {
+  border-color: var(--btn-primary-bg, #3498db);
+}
+
+.type-option.selected {
+  border-color: var(--btn-primary-bg, #3498db);
+  background-color: rgba(52, 152, 219, 0.08);
+}
+
+.type-option-label {
+  font-size: 14px;
+  font-weight: 700;
+  color: var(--text-primary);
+}
+
+.type-option-desc {
+  font-size: 10px;
+  color: var(--text-secondary);
+}
+
+/* 曜日セレクター */
+.weekday-selector {
+  display: flex;
+  gap: 6px;
+}
+
+.weekday-btn {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  border: 2px solid var(--border-color, #ddd);
+  background: transparent;
+  cursor: pointer;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-primary);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all 0.2s;
+}
+
+.weekday-btn:hover {
+  border-color: #3498db;
+}
+
+.weekday-btn.selected {
+  background-color: #3498db;
+  border-color: #3498db;
+  color: #fff;
+}
+
+/* フォームアクション */
+.task-form-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 20px;
+}
+
+.task-form-cancel {
+  padding: 8px 16px;
+  border: 1px solid var(--border-color, #ccc);
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-primary);
+  font-size: 14px;
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+.task-form-cancel:hover {
+  background-color: var(--hover-bg, #f0f0f0);
+}
+
+.task-form-submit {
+  padding: 8px 20px;
+  background-color: var(--btn-primary-bg, #3498db);
+  color: #fff;
+  border: none;
+  border-radius: 6px;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+.task-form-submit:hover {
+  background-color: var(--btn-primary-hover-bg, #2980b9);
+}
+
+.task-form-submit:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}

--- a/frontend/src/components/TaskTemplateForm.js
+++ b/frontend/src/components/TaskTemplateForm.js
@@ -1,0 +1,201 @@
+import React, { useState, useEffect } from 'react';
+import { useToast } from './Toast';
+import './TaskTemplateForm.css';
+
+const API_URL = process.env.REACT_APP_API_URL || `http://${window.location.hostname}:3002`;
+
+const WEEKDAY_OPTIONS = [
+  { value: 1, label: '月' },
+  { value: 2, label: '火' },
+  { value: 3, label: '水' },
+  { value: 4, label: '木' },
+  { value: 5, label: '金' },
+  { value: 6, label: '土' },
+  { value: 7, label: '日' },
+];
+
+function TaskTemplateForm({ template, onSave, onCancel }) {
+  const isEditMode = !!template;
+  const showToast = useToast();
+
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+  const [taskType, setTaskType] = useState('daily');
+  const [triggerTime, setTriggerTime] = useState('09:00');
+  const [weekdays, setWeekdays] = useState([]);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    if (template) {
+      setTitle(template.title || '');
+      setDescription(template.description || '');
+      setTaskType(template.task_type || 'daily');
+      setTriggerTime(template.trigger_time ? template.trigger_time.substring(0, 5) : '09:00');
+      try {
+        const wd = typeof template.weekdays === 'string' ? JSON.parse(template.weekdays) : (template.weekdays || []);
+        setWeekdays(wd);
+      } catch (e) {
+        setWeekdays([]);
+      }
+    }
+  }, [template]);
+
+  const handleWeekdayToggle = (day) => {
+    setWeekdays(prev =>
+      prev.includes(day) ? prev.filter(d => d !== day) : [...prev, day].sort()
+    );
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    if (!title.trim()) {
+      showToast('タイトルは必須です', 'error');
+      return;
+    }
+    if (taskType === 'weekday' && weekdays.length === 0) {
+      showToast('曜日を1つ以上選択してください', 'error');
+      return;
+    }
+
+    setSaving(true);
+    try {
+      const body = {
+        title: title.trim(),
+        description: description.trim() || null,
+        task_type: taskType,
+        trigger_time: (taskType === 'daily' || taskType === 'weekday') ? `${triggerTime}:00` : null,
+        weekdays: taskType === 'weekday' ? weekdays : null,
+      };
+
+      const url = isEditMode
+        ? `${API_URL}/api/tasks/templates/${template.id}`
+        : `${API_URL}/api/tasks/templates`;
+
+      const response = await fetch(url, {
+        method: isEditMode ? 'PUT' : 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify(body)
+      });
+
+      if (response.ok) {
+        showToast(isEditMode ? 'テンプレートを更新しました' : 'タスクを作成しました', 'success');
+        onSave();
+      } else {
+        const data = await response.json();
+        showToast(data.error || '保存に失敗しました', 'error');
+      }
+    } catch (error) {
+      console.error('[tasks] フォーム送信エラー:', error);
+      showToast('保存に失敗しました', 'error');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleOverlayClick = (e) => {
+    if (e.target === e.currentTarget) onCancel();
+  };
+
+  const handleKeyDown = (e) => {
+    if (e.key === 'Escape') onCancel();
+  };
+
+  return (
+    <div className="task-form-overlay" onClick={handleOverlayClick} onKeyDown={handleKeyDown} tabIndex={-1}>
+      <div className="task-form-modal">
+        <h3>{isEditMode ? 'テンプレート編集' : '新しいタスク'}</h3>
+        <form onSubmit={handleSubmit}>
+          {/* タイトル */}
+          <div className="task-form-field">
+            <label>タイトル <span className="required">*</span></label>
+            <input
+              type="text"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              placeholder="タスク名を入力"
+              autoFocus
+            />
+          </div>
+
+          {/* 説明 */}
+          <div className="task-form-field">
+            <label>説明</label>
+            <textarea
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="説明（任意）"
+              rows={2}
+            />
+          </div>
+
+          {/* タスクタイプ */}
+          <div className="task-form-field">
+            <label>タスクタイプ</label>
+            <div className="task-type-selector">
+              {[
+                { value: 'normal', label: '通常', desc: '1回限りのタスク' },
+                { value: 'daily', label: 'Daily', desc: '毎日繰り返す' },
+                { value: 'weekday', label: '曜日', desc: '指定曜日に繰り返す' },
+              ].map(opt => (
+                <button
+                  key={opt.value}
+                  type="button"
+                  className={`type-option ${taskType === opt.value ? 'selected' : ''}`}
+                  onClick={() => setTaskType(opt.value)}
+                >
+                  <span className="type-option-label">{opt.label}</span>
+                  <span className="type-option-desc">{opt.desc}</span>
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {/* トリガー時刻（Daily/曜日） */}
+          {(taskType === 'daily' || taskType === 'weekday') && (
+            <div className="task-form-field">
+              <label>トリガー時刻</label>
+              <input
+                type="time"
+                value={triggerTime}
+                onChange={(e) => setTriggerTime(e.target.value)}
+              />
+              <span className="field-hint">この時刻以降にタスクがアクティブになります</span>
+            </div>
+          )}
+
+          {/* 曜日選択（曜日タスク） */}
+          {taskType === 'weekday' && (
+            <div className="task-form-field">
+              <label>実施曜日 <span className="required">*</span></label>
+              <div className="weekday-selector">
+                {WEEKDAY_OPTIONS.map(opt => (
+                  <button
+                    key={opt.value}
+                    type="button"
+                    className={`weekday-btn ${weekdays.includes(opt.value) ? 'selected' : ''}`}
+                    onClick={() => handleWeekdayToggle(opt.value)}
+                  >
+                    {opt.label}
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* ボタン */}
+          <div className="task-form-actions">
+            <button type="button" className="task-form-cancel" onClick={onCancel}>
+              キャンセル
+            </button>
+            <button type="submit" className="task-form-submit" disabled={saving}>
+              {saving ? '保存中...' : isEditMode ? '更新' : '作成'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+export default TaskTemplateForm;


### PR DESCRIPTION
## Summary
- タスク管理機能の初期実装（通常タスク・Dailyタスク・曜日タスクの3種類）
- バックエンド: task_templates/task_instances テーブル、CRUD API、Daily/曜日タスクの自動生成ロジック
- フロントエンド: TaskList（今日のタスク+テンプレート管理）、TaskBadge（ヘッダー残件数バッジ）、TaskTemplateForm（モーダルフォーム）

## 変更内容
- **DB**: `013_create_task_tables.sql` — task_templates, task_instances テーブル
- **API**: `backend/routes/tasks.js` — badge/today/templates CRUD、インスタンス完了/スキップ/戻し
- **UI**: TaskList, TaskBadge, TaskTemplateForm コンポーネント
- **統合**: server.js, App.js, Header.js, Sidebar.js への登録

## 既知の課題
- DBテーブル未作成時に500エラー（`docker compose down -v && docker compose up --build` で解決）
- z-index競合の可能性（TaskTemplateForm vs ImageModal、共に1000）

## Test plan
- [ ] `docker compose down -v && docker compose up --build` でDB初期化
- [ ] テンプレート作成（通常/Daily/曜日の3種）
- [ ] Dailyタスクの自動生成・完了・スキップ確認
- [ ] ヘッダーバッジの件数表示確認
- [ ] ダークモード表示確認

Related: #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)